### PR TITLE
chore: disable jacoco rules in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ jacocoTestCoverageVerification {
         }
         rule {
             element = 'CLASS'
-            enabled = true
+            enabled = false
 
 //            limit {
 //                counter = 'LINE'


### PR DESCRIPTION
- disable jacoco rules just only to practice deploy